### PR TITLE
Add coupling between django and mqtt broker

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,6 +1,6 @@
 name: Backend
 
-on: [push, pull_request]
+on: pull_request
 
 defaults:
     run:

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Home automation project
+![Frontend](https://github.com/owocowe-piatki/home-automation/workflows/Frontend/badge.svg)
+![Backend](https://github.com/owocowe-piatki/home-automation/workflows/Backend/badge.svg)
+
 This repo is a part of an "Agile software development" class at University of Economics in Katowice.
 
 The project is about building a hub connecting multiple IoT devices in a smart home.
 It will consit of a mqtt broker, connected to a central hub subscribing and publishing to some dummy devices (possible to replace with real ones). It will provide REST and GraphQL APIs.
 
 ## Development
+
 ### Backend
-1. Go to backend directory
-2. Run `poetry install` and switch to the virtualenv `poetry shell`
-3. Apply migrations `./manage.py migrate`
-4. Create superuser `./manage.py createsuperuser`
-5. Start the development server `poetry run server`
+Look in the backend directory README
 
 ### Frontend
 1. Go to frontend directory

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,9 +1,42 @@
-# Backend
+# Home automation backend
+![Backend](https://github.com/owocowe-piatki/home-automation/workflows/Backend/badge.svg)
 
+## Development
+
+
+### MQTT broker
+You will need to start a MQTT Broker to run the server.  
+
+If you don't need it for your work, you can either
+- disable it by commenting out `apps.mqtt` in INSTALLED_APPS  
+- provide an existing broker address with MQTT_BROKER_URL and MQTT_BROKER_PORT environment variables
+
+Starting a simple mqtt broker in a docker container  
+
+```sh
+docker run -it -p 1883:1883 eclipse-mosquitto  # interactively
+docker run -d -p 1883:1883 eclipse-mosquitto  # as a daemon
+```
+
+### Project setup
+```sh
+poetry install  # create a virtualenv and install dependencies
+poetry shell  # start a shell within the virtualenv
+./manage.py migrate  # run project db migrations
+./manage.py createsuperuser  # create a superuser
+```
+
+### Run the development server
+```sh
+poetry run server
+```
+
+
+## Testing
 `test.sh` script is used to run tests in the github actions workflow.  
 Before pushing changes you should check if the tests pass by running it while in the correct virtualenv.
 ```sh
-poetry shell
+poetry shell  # start a shell within the virtualenv
 ./test.sh
 ```
 

--- a/backend/apps/mqtt/__init__.py
+++ b/backend/apps/mqtt/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "apps.mqtt.apps.MqttConfig"

--- a/backend/apps/mqtt/apps.py
+++ b/backend/apps/mqtt/apps.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 from django.apps import AppConfig
 

--- a/backend/apps/mqtt/apps.py
+++ b/backend/apps/mqtt/apps.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from django.apps import AppConfig
 
@@ -12,5 +13,5 @@ class MqttConfig(AppConfig):
     verbose_name = "MQTT handler"
 
     def ready(self):
+        client.loop_stop()
         client.loop_start()
-        logger.info("MQTT client initialized")

--- a/backend/apps/mqtt/apps.py
+++ b/backend/apps/mqtt/apps.py
@@ -1,0 +1,16 @@
+import logging
+
+from django.apps import AppConfig
+
+from .client import client
+
+logger = logging.getLogger(__name__)
+
+
+class MqttConfig(AppConfig):
+    name = "apps.mqtt"
+    verbose_name = "MQTT handler"
+
+    def ready(self):
+        client.loop_start()
+        logger.info("MQTT client initialized")

--- a/backend/apps/mqtt/apps.py
+++ b/backend/apps/mqtt/apps.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.apps import AppConfig
+from django.conf import settings
 
 from .client import client
 
@@ -12,5 +13,6 @@ class MqttConfig(AppConfig):
     verbose_name = "MQTT handler"
 
     def ready(self):
-        client.loop_stop()
-        client.loop_start()
+        if not settings.TEST_MODE:
+            client.loop_stop()
+            client.loop_start()

--- a/backend/apps/mqtt/client.py
+++ b/backend/apps/mqtt/client.py
@@ -8,7 +8,9 @@ from .signals import mqtt_publish, mqtt_receive
 logger = logging.getLogger(__name__)
 
 client = mqtt.Client()
-client.connect(settings.MQTT_BROKER_URL, settings.MQTT_BROKER_PORT, 60)
+
+if not settings.TEST_MODE:
+    client.connect(settings.MQTT_BROKER_URL, settings.MQTT_BROKER_PORT, 60)
 
 
 def on_connect(client, userdata, flags, rc):

--- a/backend/apps/mqtt/client.py
+++ b/backend/apps/mqtt/client.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 import paho.mqtt.client as mqtt
@@ -37,7 +36,7 @@ def on_disconnect(client, userdata, rc):
     :param userdata: user data passed when creating a client
     :param rc: return code
     """
-    logger.info(f"MQTT Disconnected")
+    logger.info("MQTT Disconnected")
 
 
 def on_message(client, userdata, msg):

--- a/backend/apps/mqtt/client.py
+++ b/backend/apps/mqtt/client.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import paho.mqtt.client as mqtt
@@ -12,21 +13,56 @@ client.connect(settings.MQTT_BROKER_URL, settings.MQTT_BROKER_PORT, 60)
 
 
 def on_connect(client, userdata, flags, rc):
-    client.subscribe(f"{settings.MQTT_TOPIC}/#")
+    """
+    MQTT on connect callback
+
+    :param client: mqtt client instance
+    :param userdata: user data passed when creating a client
+    :param flags: flags dictionary
+    :param rc: return code
+    """
+
+    if rc == 0:
+        client.subscribe(f"{settings.MQTT_TOPIC}/#")
+        logger.info("Successfully connected to MQTT broker")
+    else:
+        logger.error("Connection to MQTT broker failed")
+
+
+def on_disconnect(client, userdata, rc):
+    """
+    MQTT on disconnect callback
+
+    :param client: mqtt client instance
+    :param userdata: user data passed when creating a client
+    :param rc: return code
+    """
+    logger.info(f"MQTT Disconnected")
 
 
 def on_message(client, userdata, msg):
-    # logger.info(f"[{msg.topic}] {msg.payload.decode()}")
-    mqtt_receive.send(__name__, topic=msg.topic, message=msg.payload.decode())
+    """
+    Receive mqtt message callback
+
+    :param client: mqtt client instance
+    :param userdata: user data passed when creating a client
+    :param msg: message object
+    """
+    mqtt_receive.send(__name__, topic=msg.topic, payload=msg.payload.decode())
 
 
-def publish(sender, **kwargs):
-    topic = kwargs.get("topic")
-    message = kwargs.get("message")
+def on_publish(sender, topic, payload, **kwargs):
+    """
+    Publish signal callback, push a message to mqtt with passed topic and payload
 
-    client.publish(f"{settings.MQTT_TOPIC}/{topic}", message)
+    :param sender: signal sender
+    :param topic: message topic
+    :param payload: message payload
+    """
+    client.publish(topic=f"{settings.MQTT_TOPIC}/{topic}", payload=payload)
 
 
 client.on_connect = on_connect
+client.on_disconnect = on_disconnect
 client.on_message = on_message
-mqtt_publish.connect(publish)
+mqtt_publish.connect(on_publish)

--- a/backend/apps/mqtt/client.py
+++ b/backend/apps/mqtt/client.py
@@ -1,0 +1,32 @@
+import logging
+
+import paho.mqtt.client as mqtt
+from django.conf import settings
+
+from .signals import mqtt_publish, mqtt_receive
+
+logger = logging.getLogger(__name__)
+
+client = mqtt.Client()
+client.connect(settings.MQTT_BROKER_URL, settings.MQTT_BROKER_PORT, 60)
+
+
+def on_connect(client, userdata, flags, rc):
+    client.subscribe(f"{settings.MQTT_TOPIC}/#")
+
+
+def on_message(client, userdata, msg):
+    # logger.info(f"[{msg.topic}] {msg.payload.decode()}")
+    mqtt_receive.send(__name__, topic=msg.topic, message=msg.payload.decode())
+
+
+def publish(sender, **kwargs):
+    topic = kwargs.get("topic")
+    message = kwargs.get("message")
+
+    client.publish(f"{settings.MQTT_TOPIC}/{topic}", message)
+
+
+client.on_connect = on_connect
+client.on_message = on_message
+mqtt_publish.connect(publish)

--- a/backend/apps/mqtt/signals.py
+++ b/backend/apps/mqtt/signals.py
@@ -1,4 +1,4 @@
 from django.dispatch import Signal
 
-mqtt_receive = Signal(["topic", "message"])
-mqtt_publish = Signal(["topic", "message"])
+mqtt_receive = Signal(["topic", "payload"])
+mqtt_publish = Signal(["topic", "payload"])

--- a/backend/apps/mqtt/signals.py
+++ b/backend/apps/mqtt/signals.py
@@ -1,0 +1,4 @@
+from django.dispatch import Signal
+
+mqtt_receive = Signal(["topic", "message"])
+mqtt_publish = Signal(["topic", "message"])

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -45,6 +45,12 @@ STATIC_ROOT = BASE_DIR / "static_files"
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media_files"
 
+
+# MQTT Config
+MQTT_BROKER_URL = "localhost"
+MQTT_BROKER_PORT = 1883
+MQTT_TOPIC = "home"
+
 # Application definitions
 INSTALLED_APPS = [
     "django.contrib.admin",
@@ -58,6 +64,7 @@ INSTALLED_APPS = [
     "webpack_loader",
     # internals
     "apps.users",
+    "apps.mqtt",
 ]
 
 
@@ -91,6 +98,18 @@ AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
 ]
+
+# Logging - https://docs.djangoproject.com/en/3.0/topics/logging/
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {"console": {"level": "DEBUG", "class": "logging.StreamHandler",}},
+    "loggers": {
+        "django": {"handlers": ["console"], "level": "INFO", "propagate": False},
+        "apps": {"handlers": ["console"], "level": "DEBUG", "propagate": False},
+        "": {"handlers": ["console"], "level": "INFO"},
+    },
+}
 
 # Middlewares - https://docs.djangoproject.com/en/3.0/topics/http/middleware/
 MIDDLEWARE = [

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -6,6 +6,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 import os
+import sys
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -15,6 +16,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 DEBUG = True
 SECRET_KEY = os.getenv("SECRET_KEY") or "secret"
 ALLOWED_HOSTS = []
+
+TEST_MODE = "test" in sys.argv
 
 SITE_DOMAIN = os.getenv("SITE_DOMAIN") or "localhost"
 

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -103,7 +103,7 @@ AUTH_PASSWORD_VALIDATORS = [
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "handlers": {"console": {"level": "DEBUG", "class": "logging.StreamHandler",}},
+    "handlers": {"console": {"level": "DEBUG", "class": "logging.StreamHandler"}},
     "loggers": {
         "django": {"handlers": ["console"], "level": "INFO", "propagate": False},
         "apps": {"handlers": ["console"], "level": "DEBUG", "propagate": False},

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -153,6 +153,17 @@ pyparsing = ">=2.0.2"
 six = "*"
 
 [[package]]
+name = "paho-mqtt"
+version = "1.5.1"
+description = "MQTT version 5.0/3.1.1 client class"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+proxy = ["pysocks"]
+
+[[package]]
 name = "pluggy"
 version = "0.13.1"
 description = "plugin and hook calling mechanisms for python"
@@ -283,7 +294,7 @@ socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.0"
 python-versions = "^3.8"
-content-hash = "34fd416cf08358ed89ff8efcb5ad8c143ddcc5371b6608ffcadbd85cf5fa7494"
+content-hash = "41c6c0beb25368d7771ff129fdaa291aa5416e9744d4f2d79da661d84026eec5"
 
 [metadata.files]
 asgiref = [
@@ -344,6 +355,9 @@ mccabe = [
 packaging = [
     {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
     {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
+]
+paho-mqtt = [
+    {file = "paho-mqtt-1.5.1.tar.gz", hash = "sha256:9feb068e822be7b3a116324e01fb6028eb1d66412bf98595ae72698965cb1cae"},
 ]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -24,6 +24,7 @@ django = "^3.1.2"
 django-webpack-loader = "^0.7.0"
 requests = "^2.24.0"
 docutils = "^0.16"
+paho-mqtt = "^1.5.1"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.8.4"

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -4,7 +4,6 @@ BASE_DIR=$(dirname $0)
 run_flake8() {
     printf "\nRunning flake8\n"
     flake8 . --max-line-length=120 --extend-exclude "migrations"
-    echo " Passed"
 }
 
 run_isort() {
@@ -14,13 +13,11 @@ run_isort() {
     else
         isort . -m 3 --trailing-comma --check-only
     fi
-    echo " Passed"
 }
 
 run_unittests() {
     printf "\nRunning unittests\n"
     python manage.py test
-    echo " Passed"
 }
 
 case "$1" in


### PR DESCRIPTION
```
- Implement paho mqtt client in the backend
- Add signals triggered by mqtt messages and publishing messages
- Add info about running mqtt broker to the README
```

Closes #9 