### PR TITLE
HA-61: Include appliances reference in Room type

### DIFF
--- a/backend/apps/home/graphql/interfaces.py
+++ b/backend/apps/home/graphql/interfaces.py
@@ -1,9 +1,15 @@
 import graphene
+from graphene_django import DjangoObjectType
 
-from .room_type import RoomType
+from ..models import Room
+
+
+class InterfaceRoomType(DjangoObjectType):
+    class Meta:
+        model = Room
 
 
 class ApplianceInterface(graphene.Interface):
     name = graphene.String()
     appliance_id = graphene.ID()
-    room = graphene.Field(RoomType)
+    room = graphene.Field(InterfaceRoomType)

--- a/backend/apps/home/graphql/room_type.py
+++ b/backend/apps/home/graphql/room_type.py
@@ -1,8 +1,15 @@
+import graphene
 from graphene_django import DjangoObjectType
 
 from ..models import Room
+from .appliance_type import ApplianceUnionType
 
 
 class RoomType(DjangoObjectType):
+    appliances = graphene.List(ApplianceUnionType)
+
     class Meta:
         model = Room
+
+    def resolve_appliances(self, info):
+        return self.appliances.all()  # type: ignore


### PR DESCRIPTION
```
Regular RoomType was required for ApplianceInterface,
so it couldn't load appliances, because it was loaded before them.

Now there's a InterfaceRoomType only for ApplianceInterface,
and a regular RoomType, which includes the list of room's appliances.
```