### PR TITLE
HA-67: Fix build and deployment errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ RUN yarn build
 FROM python:3.8-slim
 ENV PYTHONUNBUFFERED 1
 
-RUN pip install poetry uvicorn psycopg2-binary
+RUN apt-get update && apt-get install gcc -y && apt-get clean
+
+RUN pip install poetry psycopg2-binary
 
 RUN mkdir -p /app
 WORKDIR /app

--- a/backend/core/asgi.py
+++ b/backend/core/asgi.py
@@ -1,21 +1,12 @@
 """
-ASGI config for core project.
-https://docs.djangoproject.com/en/3.1/howto/deployment/asgi/
+ASGI entrypoint. Configures Django and then runs the application
+defined in the ASGI_APPLICATION setting.
 """
 import os
 
-from channels.routing import ProtocolTypeRouter, URLRouter
-from django.urls import path
-from graphene_subscriptions.consumers import GraphqlSubscriptionConsumer
+import django
+from channels.routing import get_default_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings")
-
-
-# fmt: off
-application = ProtocolTypeRouter({
-    # "http": get_asgi_application(),
-    "websocket": URLRouter([
-        path("graphql/", GraphqlSubscriptionConsumer)]
-    )
-})
-# fmt: on
+django.setup()
+application = get_default_application()

--- a/backend/core/routing.py
+++ b/backend/core/routing.py
@@ -1,0 +1,11 @@
+from channels.routing import ProtocolTypeRouter, URLRouter
+from django.urls import path
+from graphene_subscriptions.consumers import GraphqlSubscriptionConsumer
+
+# fmt: off
+application = ProtocolTypeRouter({
+    "websocket": URLRouter([
+        path("graphql/", GraphqlSubscriptionConsumer)]
+    )
+})
+# fmt: on

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -28,7 +28,7 @@ ROOT_URLCONF = "core.urls"
 # WSGI and ASGI Application entrypoint
 # https://en.wikipedia.org/wiki/Web_Server_Gateway_Interface
 WSGI_APPLICATION = "core.wsgi.application"
-ASGI_APPLICATION = "core.asgi.application"
+ASGI_APPLICATION = "core.routing.application"
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.1/topics/i18n/

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -2,4 +2,4 @@
 export RUN_WSGI=true
 python manage.py collectstatic --noinput
 python manage.py migrate
-uvicorn --host=0.0.0.0 --port=8000 --no-access-log core.asgi:application
+daphne -b 0.0.0.0 -p 8000 core.asgi:application


### PR DESCRIPTION
```
- Use routing.py separately from asgi.py
- Install gcc in docker image (needed for twisted)
- Switch from uvicorn to daphne
```